### PR TITLE
Add comments to DropBlock variants

### DIFF
--- a/dropblock/jax_dropblock.py
+++ b/dropblock/jax_dropblock.py
@@ -6,16 +6,41 @@ import jax.numpy as jnp
 
 
 def dropblock2d(x: jnp.ndarray, block_size: int = 7, keep_prob: float = 0.9, training: bool = True, rng: Optional[jax.random.PRNGKey] = None) -> jnp.ndarray:
-    """Applies DropBlock to a NHWC array."""
+    """
+    Regularization Technique for Convolutional Layers.
+
+    Pseudocode:
+    1: Input:output activations of a layer (A), block_size, γ, mode
+    2: if mode == Inference then
+    3: return A
+    4: end if
+    5: Randomly sample mask M: Mi,j ∼ Bernoulli(γ)
+    6: For each zero position Mi,j , create a spatial square mask with the center being Mi,j , the width,
+        height being block_size and set all the values of M in the square to be zero (see Figure 2).
+    7: Apply the mask: A = A × M
+    8: Normalize the features: A = A × count(M)/count_ones(M)
+
+    # Arguments
+        block_size: A Python integer. The size of the block to be dropped.
+        gamma: float between 0 and 1. controls how many activation units to drop.
+    # References
+        - [DropBlock: A regularization method for convolutional networks](
+           https://arxiv.org/pdf/1810.12890v1.pdf)
+    """
+    # During inference, we do not Drop Blocks. (Similar to DropOut)
     if not training or keep_prob == 1.0:
         return x
     if rng is None:
         rng = jax.random.PRNGKey(0)
 
     h, w = x.shape[1], x.shape[2]
+    # Calculate Gamma
     gamma = (1.0 - keep_prob) * h * w / (block_size ** 2) / ((h - block_size + 1) * (w - block_size + 1))
+    # Randomly sample mask
     bernoulli = jax.random.uniform(rng, x.shape) < gamma
     bernoulli = bernoulli.astype(jnp.float32)
+    # For each 0, create spatial square mask of shape (block_size x block_size)
     mask = -jax.lax.reduce_window(-bernoulli, 0.0, jax.lax.max, (1, block_size, block_size, 1), (1, 1, 1, 1), "SAME")
     mask = 1.0 - mask
+    # Apply the mask and normalize the features
     return x * mask * mask.size / jnp.sum(mask)

--- a/dropblock/tf_dropblock.py
+++ b/dropblock/tf_dropblock.py
@@ -1,9 +1,31 @@
 """TensorFlow DropBlock implementation."""
 
+
+
 import tensorflow as tf
 
 class DropBlock2D(tf.keras.layers.Layer):
-    """DropBlock regularization for 2D feature maps."""
+    """
+    Regularization Technique for Convolutional Layers.
+
+    Pseudocode:
+    1: Input:output activations of a layer (A), block_size, γ, mode
+    2: if mode == Inference then
+    3: return A
+    4: end if
+    5: Randomly sample mask M: Mi,j ∼ Bernoulli(γ)
+    6: For each zero position Mi,j , create a spatial square mask with the center being Mi,j , the width,
+        height being block_size and set all the values of M in the square to be zero (see Figure 2).
+    7: Apply the mask: A = A × M
+    8: Normalize the features: A = A × count(M)/count_ones(M)
+
+    # Arguments
+        block_size: A Python integer. The size of the block to be dropped.
+        gamma: float between 0 and 1. controls how many activation units to drop.
+    # References
+        - [DropBlock: A regularization method for convolutional networks](
+           https://arxiv.org/pdf/1810.12890v1.pdf)
+    """
 
     def __init__(self, block_size=7, keep_prob=0.9, **kwargs):
         super().__init__(**kwargs)
@@ -11,6 +33,7 @@ class DropBlock2D(tf.keras.layers.Layer):
         self.keep_prob = keep_prob
 
     def call(self, inputs, training=None):
+        # During inference, we do not Drop Blocks. (Similar to DropOut)
         if training is False or self.keep_prob == 1.0:
             return inputs
         if training is None:
@@ -22,12 +45,16 @@ class DropBlock2D(tf.keras.layers.Layer):
         height = input_shape[1]
         width = input_shape[2]
 
+        # Calculate Gamma
         gamma = ((1.0 - self.keep_prob) * tf.cast(height * width, tf.float32) /
                  (self.block_size ** 2) /
                  tf.cast((height - self.block_size + 1) * (width - self.block_size + 1), tf.float32))
 
+        # Randomly sample mask
         bernoulli = tf.cast(tf.random.uniform(input_shape, dtype=tf.float32) < gamma, tf.float32)
+        # For each 0, create spatial square mask of shape (block_size x block_size)
         mask = -tf.nn.max_pool2d(-bernoulli, ksize=self.block_size, strides=1, padding='SAME')
         mask = 1.0 - mask
 
+        # Apply the mask and normalize the features
         return inputs * mask * tf.cast(tf.size(mask), tf.float32) / tf.reduce_sum(mask)

--- a/dropblock/torch_dropblock.py
+++ b/dropblock/torch_dropblock.py
@@ -5,7 +5,27 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 class DropBlock2D(nn.Module):
-    """DropBlock regularization for 2D feature maps."""
+    """
+    Regularization Technique for Convolutional Layers.
+
+    Pseudocode:
+    1: Input:output activations of a layer (A), block_size, γ, mode
+    2: if mode == Inference then
+    3: return A
+    4: end if
+    5: Randomly sample mask M: Mi,j ∼ Bernoulli(γ)
+    6: For each zero position Mi,j , create a spatial square mask with the center being Mi,j , the width,
+        height being block_size and set all the values of M in the square to be zero (see Figure 2).
+    7: Apply the mask: A = A × M
+    8: Normalize the features: A = A × count(M)/count_ones(M)
+
+    # Arguments
+        block_size: A Python integer. The size of the block to be dropped.
+        gamma: float between 0 and 1. controls how many activation units to drop.
+    # References
+        - [DropBlock: A regularization method for convolutional networks](
+           https://arxiv.org/pdf/1810.12890v1.pdf)
+    """
 
     def __init__(self, block_size=7, keep_prob=0.9):
         super().__init__()
@@ -13,12 +33,17 @@ class DropBlock2D(nn.Module):
         self.keep_prob = keep_prob
 
     def forward(self, x):
+        # During inference, we do not Drop Blocks. (Similar to DropOut)
         if not self.training or self.keep_prob == 1.0:
             return x
+        # Calculate Gamma
         gamma = self._compute_gamma(x)
+        # Randomly sample mask
         bernoulli = (torch.rand_like(x) < gamma).float()
+        # For each 0, create spatial square mask of shape (block_size x block_size)
         mask = -F.max_pool2d(-bernoulli, kernel_size=self.block_size, stride=1, padding=self.block_size // 2)
         mask = 1.0 - mask
+        # Apply the mask and normalize the features
         return x * mask * mask.numel() / mask.sum()
 
     def _compute_gamma(self, x):


### PR DESCRIPTION
## Summary
- sync docstrings and inline comments from original DropBlock implementation
- comment TensorFlow, JAX and PyTorch versions accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68533bcd6a08832b8b830961005942c2